### PR TITLE
Cleanup: Remove JSON parse error from router logs

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -409,9 +409,6 @@
         return parsedBody;
       } catch (_error) {
         e = _error;
-        if (!!dispatch.logging) {
-          dispatch.log(e);
-        }
       }
       return body;
     };


### PR DESCRIPTION
Removes JSON parse errors to the router logs as they serve no purpose.
